### PR TITLE
Upload backups to dropbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Added local asset backup via `backup_assets.sh`
 * Added the ability to pull backups down from the remote server via `pull_backups.sh`
 * Added pulling of the Craft `userphotos` & `rebrand` directories via `pull_assets.sh`
-* Added support for `.gz` compressing the database before transfering it, to speed things up
+* Added support for `.gz` compressing the database before transferring it, to speed things up
 * Added support for restoring directly from a `.gz` compressed database dump
 * Added additional arguments to the `mysqldump`
 * Added `common/defaults.sh` to set reasonable defaults for many settings

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ It's recommended that you set up a separate user with access to only S3, and set
 
 See [Mitigating Disaster via Website Backups](https://nystudio107.com/blog/mitigating-disaster-via-website-backups) for a detailed writeup.
 
+### sync_backups_to_dropbox.sh
+
+The `sync_backups_to_dropbox.sh` script uploads a compressed archive of the backups from `LOCAL_BACKUPS_PATH` to the Dropbox folder specified in `REMOTE_DROPBOX_PATH`.
+
+This script assumes that you have already [installed dbxcli](https://github.com/dropbox/dbxcli#installation) and have configured it with your credentials.
+
 ### backup_db.sh
 
 The `backup_db.sh` script backs up the local database into a timestamped, `gzip` compressed archive into the directory set via `LOCAL_BACKUPS_PATH`. It will also automatically rotate out (delete) any backups that are older than `GLOBAL_DB_BACKUPS_MAX_AGE` old.

--- a/scripts/common/defaults.sh
+++ b/scripts/common/defaults.sh
@@ -97,3 +97,6 @@ REMOTE_BACKUPS_PATH="/tmp/"
 
 # Remote Amazon S3 bucket name
 REMOTE_S3_BUCKET="REPLACE_ME"
+
+# Remote Dropbox path; paths should always have a trailing /
+REMOTE_DROPBOX_PATH="REPLACE_ME"

--- a/scripts/example.env.sh
+++ b/scripts/example.env.sh
@@ -100,3 +100,6 @@ REMOTE_BACKUPS_PATH="REPLACE_ME"
 
 # Remote Amazon S3 bucket name
 REMOTE_S3_BUCKET="REPLACE_ME"
+
+# Remote Dropbox path; paths should always have a trailing /
+REMOTE_DROPBOX_PATH="REPLACE_ME"

--- a/scripts/sync_backups_to_dropbox.sh
+++ b/scripts/sync_backups_to_dropbox.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Sync Backups to Dropbox
+#
+# Sync local backups to a Dropbox account
+#
+# @author    nystudio107
+# @copyright Copyright (c) 2017 nystudio107
+# @link      https://nystudio107.com/
+# @package   craft-scripts
+# @since     1.1.2
+# @license   MIT
+
+# Get the directory of the currently executing script
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+# Include files
+INCLUDE_FILES=(
+            "common/defaults.sh"
+            ".env.sh"
+            "common/common_env.sh"
+            )
+for INCLUDE_FILE in "${INCLUDE_FILES[@]}"
+do
+    if [ -f "${DIR}/${INCLUDE_FILE}" ]
+    then
+        source "${DIR}/${INCLUDE_FILE}"
+    else
+        echo 'File "${DIR}/${INCLUDE_FILE}" is missing, aborting.'
+        exit 1
+    fi
+done
+
+# Set the compressed backup file name
+BACKUP_FILE_NAME="backup-$(date '+%Y%m%d-%H%M%S').tar.gz"
+
+# Make sure the local backup directory exists
+if [[ ! -d "${LOCAL_BACKUPS_PATH}" ]] ; then
+    echo "Creating backup directory ${LOCAL_BACKUPS_PATH}"
+    mkdir -p "${LOCAL_BACKUPS_PATH}"
+fi
+
+# Archive and compress the local backup directory
+tar -zcf "${BACKUP_FILE_NAME}" "${LOCAL_BACKUPS_PATH}"
+
+# Upload the compressed backup to the Dropbox backup directory
+dbxcli put "${BACKUP_FILE_NAME}" "${REMOTE_DROPBOX_PATH}${BACKUP_FILE_NAME}"
+
+# Clean up the compressed backup file
+rm -f "${BACKUP_FILE_NAME}"
+
+echo "*** Synced backups to ${REMOTE_DROPBOX_PATH}"
+
+# Normal exit
+exit 0


### PR DESCRIPTION
Adds Dropbox support to allow ~~syncing~~ uploading of backups to a specified Dropbox account (#9).

Proper syncing is currently not possible since `dbxcli` doesn't have a `sync` command akin to the one `awscli` offers (see dropbox/dbxcli#53). Instead, this script compresses the full `LOCAL_BACKUPS_PATH` folder, timestamps it and uploads it to the specified `REMOTE_DROPBOX_PATH`. 
I'll improve the script once the `sync` command is added to `dbxcli`.