### PR TITLE
Add support for optional subfolder in sync_backups_to_s3.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ See [Mitigating Disaster via Website Backups](https://nystudio107.com/blog/mitig
 
 The `sync_backups_to_s3.sh` script syncs the backups from `LOCAL_BACKUPS_PATH` to the Amazon S3 bucket specified in `REMOTE_S3_BUCKET`.
 
+If you have defined a optional subfolder, it will contain the backups to the path defined in `REMOTE_S3_PATH`.
+
 This script assumes that you have already [installed awscli](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) and have [configured it](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) with your credentials.
 
 It's recommended that you set up a separate user with access to only S3, and set up a private S3 bucket for your backups.
@@ -213,6 +215,8 @@ All settings that are prefaced with `REMOTE_` refer to the remote environment wh
 `REMOTE_BACKUPS_PATH` is the absolute path to the directory where the remote backups are stored. For database backups, a sub-directory `REMOTE_DB_NAME/db` inside the `REMOTE_BACKUPS_PATH` directory is used for the database backups. Paths should always have a trailing `/`
 
 `REMOTE_S3_BUCKET` is the name of the Amazon S3 bucket to backup to via the `sync_backups_to_s3.sh` script
+
+`REMOTE_S3_PATH` is a optional path relative to the Amazon S3 bucket where the `sync_backups_to_s3.sh` script will contain the backups if specified
 
 ### Setting up SSH Keys
 

--- a/scripts/example.env.sh
+++ b/scripts/example.env.sh
@@ -104,3 +104,6 @@ REMOTE_BACKUPS_PATH="REPLACE_ME"
 
 # Remote Amazon S3 bucket name
 REMOTE_S3_BUCKET="REPLACE_ME"
+
+# Optional subfolder relative to the S3 bucket root; paths should always have a trailing /
+REMOTE_S3_PATH=""

--- a/scripts/sync_backups_to_s3.sh
+++ b/scripts/sync_backups_to_s3.sh
@@ -38,7 +38,7 @@ if [[ ! -d "${LOCAL_BACKUPS_PATH}" ]] ; then
 fi
 
 # Sync the local backups to the Amazon S3 bucket
-aws s3 sync ${LOCAL_BACKUPS_PATH} s3://${REMOTE_S3_BUCKET}
+aws s3 sync ${LOCAL_BACKUPS_PATH} s3://${REMOTE_S3_BUCKET}/${REMOTE_S3_PATH}
 echo "*** Synced backups to ${REMOTE_S3_BUCKET}"
 
 # Normal exit


### PR DESCRIPTION
Makes it possible to contain backups to a subfolder incase you use the bucket for multiple sites.