### PR TITLE
Support using mysqldump 8 on MySQL 5.x databases

### DIFF
--- a/scripts/common/common_mysql.sh
+++ b/scripts/common/common_mysql.sh
@@ -30,6 +30,7 @@ MYSQLDUMP_ADDITIONAL_ARGS+="--no-autocommit "
 MYSQLDUMP_ADDITIONAL_ARGS+="--routines "
 MYSQLDUMP_ADDITIONAL_ARGS+="--set-charset "
 MYSQLDUMP_ADDITIONAL_ARGS+="--triggers "
+MYSQLDUMP_ADDITIONAL_ARGS+="--column-statistics=0 "
 
 # Arguments to dump just the schema
 MYSQLDUMP_SCHEMA_ARGS=""


### PR DESCRIPTION
I think this might throw an `[ERROR] unknown option '--column-statistics'` on older mysqldump versions. My shell scripting skills are too bad to know how to check for support first.