### PR TITLE
Craft Storage Folder as a Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ All configuration is done in the `.env.sh` file, rather than in the scripts them
 
 All settings that are prefaced with `GLOBAL_` apply to **all** environments.
 
-`GLOBAL_DB_TABLE_PREFIX` is the Craft database table prefix, usually `craft_`
+`GLOBAL_DB_TABLE_PREFIX` is the Craft database table prefix, usually `craft_` for Craft v2 or blank for Craft v3
 
-`GLOBAL_CRAFT_PATH` is the path of the `craft` folder, relative to the root path. This should normally be `craft/`, unless you have moved it elsewhere. Paths should always have a trailing `/`
+`GLOBAL_CRAFT_PATH` is the path of the `craft` folder, relative to the root path. This should normally be `craft/` Craft v2 or `./` for Craft v3, unless you have moved it elsewhere. Paths should always have a trailing `/`
 
 `GLOBAL_DB_BACKUPS_MAX_AGE` Is the maximum age of local backups in days; backups older than this will be automatically rotated out (removed).
 
@@ -172,7 +172,9 @@ All settings that are prefaced with `LOCAL_` refer to the local environment wher
 
 `LOCAL_ROOT_PATH` is the absolute path to the root of your local Craft install, with a trailing `/` after it.
 
-`LOCAL_ASSETS_PATH` is the relative path to your local assets directories, with a trailing `/` after it.
+`LOCAL_ASSETS_PATH` is the relative path to your local assets directories, with a trailing `/` after it. Can be replaced with an absolute path if required
+
+`LOCAL_CRAFT_FILES_PATH` is the relative path to your storage directory, with a trailing `/` after it. You should only change this if you are using an absolute path.
 
 `LOCAL_CHOWN_USER` is the user that is the owner of your entire Craft install.
 
@@ -230,7 +232,9 @@ All settings that are prefaced with `REMOTE_` refer to the remote environment wh
 
 `REMOTE_ROOT_PATH` is the absolute path to the root of your Craft install on the remote server, with a trailing `/` after it.
 
-`REMOTE_ASSETS_PATH` is the relative path to the remote assets directories, with a trailing `/` after it.
+`REMOTE_ASSETS_PATH` is the relative path to the remote assets directories, with a trailing `/` after it. This can be changed to an absolute path if required.
+
+`REMOTE_CRAFT_FILES_PATH` is the relative path to your storage directory, with a trailing `/` after it. You should only change this if you are using an absolute path.
 
 `REMOTE_DB_NAME` is the name of the remote mysql Craft CMS database
 

--- a/scripts/common/common_env.sh
+++ b/scripts/common/common_env.sh
@@ -12,8 +12,7 @@
 # @license   MIT
 
 # Craft paths; ; paths should always have a trailing /
-LOCAL_CRAFT_FILES_PATH=${LOCAL_ROOT_PATH}"${GLOBAL_CRAFT_PATH}storage/"
-REMOTE_CRAFT_FILES_PATH=${REMOTE_ROOT_PATH}"${GLOBAL_CRAFT_PATH}storage/"
+
 
 # Commands to output database dumps, using gunzip -c instead of zcat for MacOS X compatibility
 DB_ZCAT_CMD="gunzip -c"

--- a/scripts/common/defaults.sh
+++ b/scripts/common/defaults.sh
@@ -29,6 +29,7 @@ GLOBAL_DB_DRIVER="mysql"
 # Local path constants; paths should always have a trailing /
 LOCAL_ROOT_PATH="REPLACE_ME"
 LOCAL_ASSETS_PATH=${LOCAL_ROOT_PATH}"REPLACE_ME"
+LOCAL_CRAFT_FILES_PATH=${LOCAL_ROOT_PATH}${GLOBAL_CRAFT_PATH}"storage/"
 
 # Local user & group that should own the Craft CMS install
 LOCAL_CHOWN_USER="admin"
@@ -65,8 +66,8 @@ LOCAL_REDIS_DB_ID=""
 
 # Local database constants; default port for mysql is 3306, default port for postgres is 5432
 LOCAL_DB_NAME="REPLACE_ME"
-LOCAL_DB_PASSWORD="REPLACE_ME"
 LOCAL_DB_USER="REPLACE_ME"
+LOCAL_DB_PASSWORD="REPLACE_ME"
 LOCAL_DB_HOST="localhost"
 LOCAL_DB_PORT="3306"
 LOCAL_DB_SCHEMA="public"
@@ -96,14 +97,15 @@ REMOTE_SSH_PORT="22"
 # Remote path constants; paths should always have a trailing /
 REMOTE_ROOT_PATH="REPLACE_ME"
 REMOTE_ASSETS_PATH=${REMOTE_ROOT_PATH}"REPLACE_ME"
+REMOTE_CRAFT_FILES_PATH=${REMOTE_ROOT_PATH}${GLOBAL_CRAFT_PATH}"storage/"
 
 # Should we connect to the remote database server via ssh?
 REMOTE_DB_USING_SSH="yes"
 
 # Remote database constants; default port for mysql is 3306, default port for postgres is 5432
 REMOTE_DB_NAME="REPLACE_ME"
-REMOTE_DB_PASSWORD="REPLACE_ME"
 REMOTE_DB_USER="REPLACE_ME"
+REMOTE_DB_PASSWORD="REPLACE_ME"
 REMOTE_DB_HOST="localhost"
 REMOTE_DB_PORT="3306"
 REMOTE_DB_SCHEMA="public"

--- a/scripts/craft2-example.env.sh
+++ b/scripts/craft2-example.env.sh
@@ -31,6 +31,7 @@ GLOBAL_DB_DRIVER="mysql"
 # Local path constants; paths should always have a trailing /
 LOCAL_ROOT_PATH="REPLACE_ME"
 LOCAL_ASSETS_PATH=${LOCAL_ROOT_PATH}"REPLACE_ME"
+LOCAL_CRAFT_FILES_PATH=${LOCAL_ROOT_PATH}${GLOBAL_CRAFT_PATH}"storage/"
 
 # Local user & group that should own the Craft CMS install
 LOCAL_CHOWN_USER="admin"
@@ -67,8 +68,8 @@ LOCAL_REDIS_DB_ID=""
 
 # Local database constants; default port for mysql is 3306, default port for postgres is 5432
 LOCAL_DB_NAME="REPLACE_ME"
-LOCAL_DB_PASSWORD="REPLACE_ME"
 LOCAL_DB_USER="REPLACE_ME"
+LOCAL_DB_PASSWORD="REPLACE_ME"
 LOCAL_DB_HOST="localhost"
 LOCAL_DB_PORT="3306"
 LOCAL_DB_SCHEMA="public"
@@ -101,11 +102,12 @@ REMOTE_DB_USING_SSH="yes"
 # Remote path constants; paths should always have a trailing /
 REMOTE_ROOT_PATH="REPLACE_ME"
 REMOTE_ASSETS_PATH=${REMOTE_ROOT_PATH}"REPLACE_ME"
+REMOTE_CRAFT_FILES_PATH=${REMOTE_ROOT_PATH}${GLOBAL_CRAFT_PATH}"storage/"
 
 # Remote database constants; default port for mysql is 3306, default port for postgres is 5432
 REMOTE_DB_NAME="REPLACE_ME"
-REMOTE_DB_PASSWORD="REPLACE_ME"
 REMOTE_DB_USER="REPLACE_ME"
+REMOTE_DB_PASSWORD="REPLACE_ME"
 REMOTE_DB_HOST="localhost"
 REMOTE_DB_PORT="3306"
 REMOTE_DB_SCHEMA="public"

--- a/scripts/craft3-example.env.sh
+++ b/scripts/craft3-example.env.sh
@@ -31,6 +31,7 @@ GLOBAL_DB_DRIVER="mysql"
 # Local path constants; paths should always have a trailing /
 LOCAL_ROOT_PATH="REPLACE_ME"
 LOCAL_ASSETS_PATH=${LOCAL_ROOT_PATH}"REPLACE_ME"
+LOCAL_CRAFT_FILES_PATH=${LOCAL_ROOT_PATH}${GLOBAL_CRAFT_PATH}"storage/"
 
 # Local user & group that should own the Craft CMS install
 LOCAL_CHOWN_USER="admin"
@@ -67,8 +68,8 @@ LOCAL_REDIS_DB_ID=""
 
 # Local database constants; default port for mysql is 3306, default port for postgres is 5432
 LOCAL_DB_NAME="REPLACE_ME"
-LOCAL_DB_PASSWORD="REPLACE_ME"
 LOCAL_DB_USER="REPLACE_ME"
+LOCAL_DB_PASSWORD="REPLACE_ME"
 LOCAL_DB_HOST="localhost"
 LOCAL_DB_PORT="3306"
 LOCAL_DB_SCHEMA="public"
@@ -101,11 +102,12 @@ REMOTE_DB_USING_SSH="yes"
 # Remote path constants; paths should always have a trailing /
 REMOTE_ROOT_PATH="REPLACE_ME"
 REMOTE_ASSETS_PATH=${REMOTE_ROOT_PATH}"REPLACE_ME"
+REMOTE_CRAFT_FILES_PATH=${REMOTE_ROOT_PATH}${GLOBAL_CRAFT_PATH}"storage/"
 
 # Remote database constants; default port for mysql is 3306, default port for postgres is 5432
 REMOTE_DB_NAME="REPLACE_ME"
-REMOTE_DB_PASSWORD="REPLACE_ME"
 REMOTE_DB_USER="REPLACE_ME"
+REMOTE_DB_PASSWORD="REPLACE_ME"
 REMOTE_DB_HOST="localhost"
 REMOTE_DB_PORT="3306"
 REMOTE_DB_SCHEMA="public"


### PR DESCRIPTION
Currently, the storage folder is fixed to `${LOCAL_ROOT_PATH}"${GLOBAL_CRAFT_PATH}storage/"` & `${REMOTE_ROOT_PATH}"${GLOBAL_CRAFT_PATH}storage/"` which has some limitations if using atomic deployments where the storage folder is symlinked into the release folder.

This change uses the same location as before but moving this variable to the `.env.sh` file allowing for it to be configured to an absolute path and synced without error.