### PR TITLE
Support Local Asset Sync

### DIFF
--- a/scripts/craft2-example.env.sh
+++ b/scripts/craft2-example.env.sh
@@ -102,6 +102,9 @@ REMOTE_SSH_PORT="22"
 # Should we connect to the remote database server via ssh?
 REMOTE_DB_USING_SSH="yes"
 
+# Should we connect to the remote server via ssh for assets?
+REMOTE_ASSETS_USING_SSH="yes"
+
 # Remote path constants; paths should always have a trailing /
 REMOTE_ROOT_PATH="REPLACE_ME"
 REMOTE_ASSETS_PATH=${REMOTE_ROOT_PATH}"REPLACE_ME"

--- a/scripts/craft3-example.env.sh
+++ b/scripts/craft3-example.env.sh
@@ -102,6 +102,9 @@ REMOTE_SSH_PORT="22"
 # Should we connect to the remote database server via ssh?
 REMOTE_DB_USING_SSH="yes"
 
+# Should we connect to the remote server via ssh for assets?
+REMOTE_ASSETS_USING_SSH="yes"
+
 # Remote path constants; paths should always have a trailing /
 REMOTE_ROOT_PATH="REPLACE_ME"
 REMOTE_ASSETS_PATH=${REMOTE_ROOT_PATH}"REPLACE_ME"

--- a/scripts/pull_assets.sh
+++ b/scripts/pull_assets.sh
@@ -36,7 +36,11 @@ mkdir -p "${LOCAL_ASSETS_PATH}"
 # Pull down the asset dir files via rsync
 for DIR in "${LOCAL_ASSETS_DIRS[@]}"
 do
-    rsync -F -L -a -z -e "ssh -p ${REMOTE_SSH_PORT}" --delete-after --progress "${REMOTE_SSH_LOGIN}:${REMOTE_ASSETS_PATH}${DIR}" "${LOCAL_ASSETS_PATH}"
+    if [[ "${REMOTE_ASSETS_USING_SSH}" == "yes" ]] ; then
+        rsync -F -L -a -z -e "ssh -p ${REMOTE_SSH_PORT}" --delete-after --progress "${REMOTE_SSH_LOGIN}:${REMOTE_ASSETS_PATH}${DIR}" "${LOCAL_ASSETS_PATH}"
+    else
+        rsync -F -L -a -z --delete-after --progress "${REMOTE_ASSETS_PATH}${DIR}" "${LOCAL_ASSETS_PATH}"
+    fi
     echo "*** Synced assets from ${REMOTE_ASSETS_PATH}${DIR}"
 done
 
@@ -47,7 +51,11 @@ mkdir -p "${LOCAL_CRAFT_FILES_PATH}"
 # Pull down the Craft-specific dir files via rsync
 for DIR in "${LOCAL_CRAFT_FILE_DIRS[@]}"
 do
-    rsync -F -L -a -z -e "ssh -p ${REMOTE_SSH_PORT}" --delete-after --progress "${REMOTE_SSH_LOGIN}:${REMOTE_CRAFT_FILES_PATH}${DIR}" "${LOCAL_CRAFT_FILES_PATH}"
+    if [[ "${REMOTE_ASSETS_USING_SSH}" == "yes" ]] ; then
+        rsync -F -L -a -z -e "ssh -p ${REMOTE_SSH_PORT}" --delete-after --progress "${REMOTE_SSH_LOGIN}:${REMOTE_CRAFT_FILES_PATH}${DIR}" "${LOCAL_CRAFT_FILES_PATH}"
+    else
+        rsync -F -L -a -z --delete-after --progress "${REMOTE_CRAFT_FILES_PATH}${DIR}" "${LOCAL_CRAFT_FILES_PATH}"
+    fi
     echo "*** Synced assets from ${REMOTE_CRAFT_FILES_PATH}${DIR}"
 done
 


### PR DESCRIPTION
Similar to `REMOTE_DB_USING_SSH`, offer the ability to locally sync assets such as when staging/live is on the same environment (i.e. without requiring SSH) via a new flag `REMOTE_ASSETS_USING_SSH`